### PR TITLE
create publish-barshare-gbfs service

### DIFF
--- a/.github/workflows/publish-barshare-gbfs.yml
+++ b/.github/workflows/publish-barshare-gbfs.yml
@@ -41,6 +41,12 @@ jobs:
       MINIO_SECRET_KEY: "${{ secrets.MINIO_SECRET_KEY }}"
     steps:
       - uses: actions/checkout@v2
+      # https://twitter.com/derhuerst/status/1511660213111336961
+      - name: inline env vars to work around quantum-cli support
+        run: |
+          cd publish-barshare-gbfs
+          apk add --no-cache --upgrade docker-compose moreutils
+          docker-compose -f quantum-stack.yml config | sponge quantum-stack.yml
       - name: deploy to bbnavi infrastructure
         run: |
           cd publish-barshare-gbfs

--- a/.github/workflows/publish-barshare-gbfs.yml
+++ b/.github/workflows/publish-barshare-gbfs.yml
@@ -1,0 +1,47 @@
+name: build & deploy publish-barshare-gbfs Docker image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/login-action@v1
+      with:
+        registry: registry.gitlab.tpwd.de
+        username: ${{ secrets.GITLAB_USERNAME }}
+        password: ${{ secrets.GITLAB_PASSWORD }}
+    - name: build moqo2gbfs Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        tags: moqo2gbfs
+    - name: build & publish publish-barshare-gbfs Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: publish-barshare-gbfs
+        push: true
+        tags: registry.gitlab.tpwd.de/tpwd/bb-navi/publish-barshare-gbfs
+  deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    container: r.planetary-quantum.com/quantum-public/cli:2
+    env:
+      QUANTUM_USER: "${{ secrets.QUANTUM_USER }}"
+      QUANTUM_PASSWORD: "${{ secrets.QUANTUM_PASSWORD }}"
+      QUANTUM_ENDPOINT: "tpwd-bb-navi"
+      QUANTUM_STACK: "publish-barshare-gbfs-tpwd-bb-navi"
+      MOQO_ACCESS_TOKEN: "${{ secrets.MOQO_ACCESS_TOKEN }}"
+      MINIO_ACCESS_KEY: "${{ secrets.MINIO_ACCESS_KEY }}"
+      MINIO_SECRET_KEY: "${{ secrets.MINIO_SECRET_KEY }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: deploy to bbnavi infrastructure
+        run: |
+          cd publish-barshare-gbfs
+          quantum-cli stacks update --create --wait

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3-alpine
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 ENTRYPOINT [ "python" ]
-CMD [ "moqo2gbfs.py"]
+CMD [ "moqoToGBFS.py"]

--- a/publish-barshare-gbfs/.quantum
+++ b/publish-barshare-gbfs/.quantum
@@ -1,0 +1,3 @@
+---
+version: '1.0'
+compose: quantum-stack.yml

--- a/publish-barshare-gbfs/Dockerfile
+++ b/publish-barshare-gbfs/Dockerfile
@@ -1,0 +1,20 @@
+# This Dockerfile builds a service that regularly publishes the BARShare GBFS to the bbnavi open data portal.
+FROM minio/mc as mc
+
+FROM moqo2gbfs
+
+ENV MOQO_ACCESS_TOKEN=""
+ENV MINIO_ACCESS_KEY="" MINIO_SECRET_KEY=""
+ENV PUBLISH_INTERVAL=""
+
+RUN apk add --no-cache --update tree
+
+# install MinIO client a.k.a. mc
+COPY --from=mc /usr/bin/mc /usr/bin/mc
+
+COPY main.sh ./
+
+# prevent inheriting `python` as entrypoint
+ENTRYPOINT []
+
+CMD ["/bin/sh", "main.sh"]

--- a/publish-barshare-gbfs/README.md
+++ b/publish-barshare-gbfs/README.md
@@ -1,0 +1,24 @@
+# BARShare GBFS publishing
+
+This directory contains [a script](main.sh) that
+1. uses `moqo2gbfs` to generate three [BARShare](https://barshare.de) GBFS feeds (`bicycle`, `car` & `other`)
+2. copies the feeds into the `barshare` bucket within the [bbnavi](https://bbnavi.de) [open data portal](https://opendata.bbnavi.de)
+3. repeats this process every 5 minutes.
+
+## Docker
+
+To build a Docker image for this publishing tool, run the following command *within this directory*:
+
+```shell
+docker build -t publish-barshare-gbfs .
+```
+
+*Note:* The [`Dockerfile`](Dockerfile) assumes that you have built the [moqo2gbfs](..) Docker image as `moqo2gbfs`.
+
+Run a container as follows:
+
+```shell
+docker run -it --rm \
+	-e MOQO_ACCESS_TOKEN=… -e MINIO_ACCESS_KEY=… -e MINIO_SECRET_KEY=… \
+	publish-barshare-gbfs
+```

--- a/publish-barshare-gbfs/main.sh
+++ b/publish-barshare-gbfs/main.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# This script regularly publishes the BARShare GBFS to the bbnavi open data portal.
+
+set -e
+
+if [ -z "$MOQO_ACCESS_TOKEN" ]; then
+	1>&2 echo 'missing/empty $MOQO_ACCESS_TOKEN'
+	exit 1
+fi
+if [ -z "$MINIO_ACCESS_KEY" ]; then
+	1>&2 echo 'missing/empty $MINIO_ACCESS_KEY'
+	exit 1
+fi
+if [ -z "$MINIO_SECRET_KEY" ]; then
+	1>&2 echo 'missing/empty $MINIO_SECRET_KEY'
+	exit 1
+fi
+
+# default: 5 minutes
+PUBLISH_INTERVAL="${PUBLISH_INTERVAL:-300}"
+
+export MC_HOST_bbnavi="https://$MINIO_ACCESS_KEY:$MINIO_SECRET_KEY@opendata.bbnavi.de"
+
+dir="$(mktemp -d -t barshare-gbfs.XXXXXX)"
+
+set -x
+
+while true; do
+	# We sleep first so that, if the GBFS generation fails contantly, we don't DOS the Moqo API.
+	sleep "$PUBLISH_INTERVAL"
+
+	python moqoToGBFS.py \
+		--config BARshare --serviceUrl 'https://portal.moqo.de/api_aggregator/' \
+		--baseUrl 'https://opendata.bbnavi.de/barshare' \
+		--outputDir "$dir" \
+		--token "$MOQO_ACCESS_TOKEN"
+
+	tree -sh "$dir"
+
+	mc cp -q -r $dir/* bbnavi/barshare/
+done

--- a/publish-barshare-gbfs/quantum-stack.yml
+++ b/publish-barshare-gbfs/quantum-stack.yml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+services:
+  opentripplanner:
+    image: registry.gitlab.tpwd.de/tpwd/bb-navi/publish-barshare-gbfs
+    environment:
+      - MOQO_ACCESS_TOKEN=${MOQO_ACCESS_TOKEN:?missing env var MOQO_ACCESS_TOKEN}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?missing env var MINIO_ACCESS_KEY}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?missing env var MINIO_SECRET_KEY}
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.hostname == node-001.tpwd-bb-navi
+    networks:
+      - public
+
+networks:
+  public:
+    external: true


### PR DESCRIPTION
This PR adds a `publish-barshare-gbfs` service that regularly
1. generates BARShare's 3 GBFS feeds, and
2. uploads them to the [bbnavi open data portal](https://opendata.bbnavi.de) using the [`mc` MinIO Client](https://docs.min.io/minio/baremetal/reference/minio-mc.html).

@hbruch Please have a look at `publish-barshare-gbfs/{Dockerfile,README.md,main.sh}` and check if they make sense.
@marcometz Please check if the `.github/workflows/publish-barshare-gbfs.yml` GitHub Actions workflow looks good.